### PR TITLE
Let Stats options reach stats.toJson()

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -125,6 +125,7 @@ module.exports = function(grunt) {
 			compiler.run(handler);
 		}
 		function handler(err, stats) {
+			var options;
 			if(cache) {
 				targetDependencies[target] = {
 					file: compiler._lastCompilationFileDependencies,
@@ -137,7 +138,7 @@ module.exports = function(grunt) {
 			}
 
 			if(statsOptions) {
-				grunt.log.notverbose.writeln(stats.toString(grunt.util._.merge({
+				options = grunt.util._.merge({
 					colors: true,
 					hash: false,
 					timings: false,
@@ -146,13 +147,15 @@ module.exports = function(grunt) {
 					chunkModules: false,
 					modules: false,
 					children: true
-				}, statsOptions)));
+				}, statsOptions);
+				
+				grunt.log.notverbose.writeln(stats.toString(options));
 				grunt.verbose.writeln(stats.toString(grunt.util._.merge({
 					colors: true
 				}, statsOptions)));
 			}
 			if(typeof storeStatsTo === "string") {
-				grunt.config.set(storeStatsTo, stats.toJson());
+				grunt.config.set(storeStatsTo, stats.toJson(options));
 			}
 			if(failOnError && stats.hasErrors()) {
 				return done(false);

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -149,7 +149,12 @@ module.exports = function(grunt) {
 					children: true
 				}, statsOptions);
 				
-				grunt.log.notverbose.writeln(stats.toString(options));
+                if ( firstOptions.quiet ) {
+                    grunt.verbose.writeln( stats.toString( options ) );
+                } else {
+                    grunt.log.notverbose.writeln( stats.toString( options ) );
+                }
+                
 				grunt.verbose.writeln(stats.toString(grunt.util._.merge({
 					colors: true
 				}, statsOptions)));


### PR DESCRIPTION
Hi there !

This is a very quick patch to let the stats options specified in the Gruntfile reach the toJson() call, so that a developer can control the level of stats he wants to retrieve in the JSON. 
I've used almost exactly the same default values as a few lines above for the string version since both cases feel similar (besides the format, it feels like it should be the same configuration), only disabling the colours since those don't make much sense in JSON.
Overall, it seems like it would make sense to be able to fine tune the level of stats we can get in the JSON for further analysis.

I actually would very much enjoy this change ; I'm using the generated JSON stats after each major build to ensure that no undesired module made its way in entry x or y by misake or that some modules stay in commons, etc. which requires this change as I need to specify that I want to see the modules inside of my chunks.

Thanks for reading, please ping me if you want me to make changes to this PR ; I wil followup gladly.
