### PR TITLE
Fixes #61 Error when grunt.config has a circular dependency.

### DIFF
--- a/lib/getWithPlugins.js
+++ b/lib/getWithPlugins.js
@@ -1,8 +1,11 @@
+var _ = require('lodash');
+
 module.exports = function(grunt) {
 
 	// Get options from this.data
 	function getWithPlugins(ns) {
-		var obj = grunt.config(ns) || {};
+		// using _.get instead of grunt.config as it handles circular dependencies better
+		var obj = _.get(grunt.config.data, ns) || {};
 
 		if (obj.plugins) {
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/webpack/grunt-webpack/issues"
   },
   "dependencies": {
-    "lodash": "~1.2.0"
+    "lodash": "~3.10.1"
   },
   "peerDependencies": {
     "webpack": "1.x",

--- a/spec/lib/getWithPluginsSpec.js
+++ b/spec/lib/getWithPluginsSpec.js
@@ -50,4 +50,10 @@ describe('getWithPlugins', function() {
 		expect(getWithPlugins(namespace).foo.plugins)
 			.toEqual(['foo']);
 	});
+
+	it('should not throw an error if grunt.config.data has a cyclical dependency', function() {
+		grunt.config.data[taskName][target].child = grunt.config.data[taskName][target];
+		expect(getWithPlugins(namespace).foo.plugins)
+			.toEqual(['foo']);
+	});
 });


### PR DESCRIPTION
I encountered the issue webpack/grunt-webpack#61 today and set about
debugging. The BrowserSyncPlugin works fine when called directly from
`webpack-dev-server` on the command line, but throws an error when
called using grunt-karma. It appears the `grunt.config` function throws
an error if the the object has a nested circular dep.

Using lodash's `_.get` seems like the cleanest way to get this without
causing an error, and has a similar argument pattern to `grunt.config`.

Added a unit test for verification.