### PR TITLE
Updates lodash, require only functions needed

### DIFF
--- a/lib/mergeFunction.js
+++ b/lib/mergeFunction.js
@@ -1,23 +1,24 @@
-var _ = require("lodash");
+var isArray = require("lodash/isArray");
+var merge = require("lodash/merge");
 
 module.exports = function(grunt) {
 
 	function mergeFunction(a, b) {
-		if(_.isArray(a) && _.isArray(b)) {
+		if(isArray(a) && isArray(b)) {
 			return a.concat(b);
 		}
-		if(_.isArray(a) && !_.isArray(b)) {
+		if(isArray(a) && !isArray(b)) {
 			return a.map(function(item) {
-				return _.merge({}, {x:item}, {x:b}, mergeFunction).x;
+				return merge({}, {x:item}, {x:b}, mergeFunction).x;
 			});
 		}
-		if(_.isArray(b) && !_.isArray(a)) {
+		if(isArray(b) && !isArray(a)) {
 			return b.map(function(item) {
-				return _.merge({}, {x:a}, {x:item}, mergeFunction).x;
+				return merge({}, {x:a}, {x:item}, mergeFunction).x;
 			});
 		}
 	}
-	
+
 	return mergeFunction;
 
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/webpack/grunt-webpack/issues"
   },
   "dependencies": {
-    "lodash": "~1.2.0"
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
     "webpack": "1.x",

--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -7,7 +7,7 @@
  */
 
 var path = require("path");
-var _ = require("lodash");
+var merge = require("lodash/merge");
 module.exports = function(grunt) {
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
 	var mergeFunction = require("../lib/mergeFunction")(grunt);
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 
 	grunt.registerMultiTask('webpack-dev-server', 'Start a webpack-dev-server.', function() {
 		var done = this.async();
-		var options = _.merge(
+		var options = merge(
 			{
 				port: 8080,
 				host: undefined,

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -7,7 +7,10 @@
  */
 
 var path = require("path");
-var _ = require("lodash");
+var merge = require("lodash/merge");
+var map = require("lodash/map");
+var isString = require("lodash/isString");
+var isArray = require("lodash/isArray");
 
 module.exports = function(grunt) {
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
@@ -22,7 +25,7 @@ module.exports = function(grunt) {
 
 	grunt.registerMultiTask('webpack', 'Webpack files.', function() {
 		var done = this.async();
-		var options = _.merge(
+		var options = merge(
 			{x:{
 				context: ".",
 				output: {
@@ -59,13 +62,13 @@ module.exports = function(grunt) {
 		}
 
 		function convertPath(pth) {
-			if(_.isString(pth)){
+			if(isString(pth)){
 				return path.resolve(process.cwd(), pth);
 			}
-			else if(_.isArray(pth)){
-				return _.map(pth, function(p){
+			else if(isArray(pth)){
+				return map(pth, function(p){
 					// Arrays of paths can contain a mix of both strings and RegExps
-					if(_.isString(p)){
+					if(isString(p)){
 						return path.resolve(process.cwd(), p);
 					}
 					return p
@@ -137,7 +140,7 @@ module.exports = function(grunt) {
 			}
 
 			if(statsOptions) {
-				grunt.log.notverbose.writeln(stats.toString(grunt.util._.merge({
+				grunt.log.notverbose.writeln(stats.toString(grunt.util.merge({
 					colors: true,
 					hash: false,
 					timings: false,
@@ -147,7 +150,7 @@ module.exports = function(grunt) {
 					modules: false,
 					children: true
 				}, statsOptions)));
-				grunt.verbose.writeln(stats.toString(grunt.util._.merge({
+				grunt.verbose.writeln(stats.toString(grunt.util.merge({
 					colors: true
 				}, statsOptions)));
 			}


### PR DESCRIPTION
  - lodash < 2.0.0 throws warning when running `npm install` : updates lodash to 4.0.0
  - lodash 4.0.0 is a modular npm package, we can require only the functions needed.