### PR TITLE
make peerDependencies completely optional

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,12 @@
-var webpack = require("webpack");
+var plugins = [];
+try {
+	var webpack = require("webpack");
+	plugins.push(new webpack.DefinePlugin({
+		ok: JSON.stringify("ok")
+	}));
+} catch (e) {
+
+}
 module.exports = function(grunt) {
 	grunt.loadTasks("tasks");
 	grunt.initConfig({
@@ -9,9 +17,7 @@ module.exports = function(grunt) {
 					path: "js",
 					filename: "bundle.js"
 				},
-				plugins: [new webpack.DefinePlugin({
-					ok: JSON.stringify("ok")
-				})]
+				plugins: plugins
 			}
 		},
 		"webpack-dev-server": {
@@ -22,9 +28,7 @@ module.exports = function(grunt) {
 						path: "js",
 						filename: "bundle.js"
 					},
-					plugins: [new webpack.DefinePlugin({
-						ok: JSON.stringify("ok")
-					})]
+					plugins: plugins
 				},
 				keepalive: true
 			}

--- a/spec/lib/getWithPluginsSpec.js
+++ b/spec/lib/getWithPluginsSpec.js
@@ -1,7 +1,16 @@
-var webpack = require("webpack");
+var webpack;
+var plugins = [];
+var DefinePlugin;
+try {
+	webpack = require("webpack");
+	plugins.push(new webpack.DefinePlugin({
+		ok: JSON.stringify("ok")
+	}));
+	DefinePlugin = webpack.DefinePlugin;
+} catch (e) {
+}
 var grunt = require('grunt');
 var getWithPluginsFactory = require('../../lib/getWithPlugins');
-var DefinePlugin = webpack.DefinePlugin;
 var taskName;
 var target;
 var gruntConfigFactory = function(grunt) {
@@ -18,9 +27,7 @@ var gruntConfigFactory = function(grunt) {
 		foo: {
 			plugins: ['foo']
 		},
-		plugins: [new webpack.DefinePlugin({
-			ok: JSON.stringify("ok")
-		})]
+		plugins: plugins
 	};
 
 	grunt.initConfig(config);
@@ -42,6 +49,9 @@ describe('getWithPlugins', function() {
 
 
 	it('should fix plugins property in webpack config', function() {
+		if (typeof webpack === 'undefined') {
+			pending('webpack peerDependency not installed');
+		}
 		expect(getWithPlugins(namespace).plugins[0].constructor)
 			.toBe(DefinePlugin);
 	});

--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -9,6 +9,13 @@
 var path = require("path");
 var _ = require("lodash");
 module.exports = function(grunt) {
+	if (!grunt.file.exists(path.join(path.resolve('node_modules'), 'webpack-dev-server', 'package.json'))) {
+		grunt.registerTask('webpack-dev-server', 'webpack-dev-server not installed, this task will do nothing.', function () {
+			grunt.fail.warn('webpack-dev-server not installed, this task will do nothing.');
+		});
+		return;
+	}
+
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
 	var mergeFunction = require("../lib/mergeFunction")(grunt);
 

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -10,6 +10,13 @@ var path = require("path");
 var _ = require("lodash");
 
 module.exports = function(grunt) {
+	if (!grunt.file.exists(path.join(path.resolve('node_modules'), 'webpack', 'package.json'))) {
+		grunt.registerTask('webpack', 'Webpack not installed, this task will do nothing.', function () {
+			grunt.fail.warn('Webpack not installed, this task will do nothing.');
+		});
+		return;
+	}
+
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
 	var mergeFunction = require("../lib/mergeFunction")(grunt);
 


### PR DESCRIPTION
if dependencies are not installed, register dummy tasks to inform the user.
This allows to use only parts of this plugin (i.e. not use the webpack-dev-server),
depending on what peerDependencies are installed.

Kind of fixes #29 for npm@3 users.