### PR TITLE
Fix compiler.watch() parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ webpack: {
 	watch: true, // use webpacks watcher
 	// You need to keep the grunt process alive
 
+	watchOptions: {
+		aggregateTimeout: 500,
+		poll: true
+	},
+	// Use this when you need to fallback to poll based watching (webpack 1.9.1+ only)
+
 	keepalive: true, // don't finish the grunt task
 	// Use this in combination with the watch option
 

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -120,7 +120,9 @@ module.exports = function(grunt) {
 		}
 
 		if (watch) {
-			compiler.watch(options.watchDelay || 200, handler);
+			// watchDealy and 0 are for backwards compatibility with webpack <= 1.9.0
+			// remove with next major and bump to v1.9.1 / v2
+			compiler.watch(options.watchOptions || options.watchDelay || 0, handler);
 		} else {
 			compiler.run(handler);
 		}


### PR DESCRIPTION
This superseeds #55 and adjusts the changes to be bc.

Closes #55