### PR TITLE
Split webpack options

### DIFF
--- a/lib/validWebpackOptions.js
+++ b/lib/validWebpackOptions.js
@@ -1,0 +1,8 @@
+var validWebpackOptions = [
+    "amd", "bail", "cache", "context", "dependencies", "devServer", "devtool", "entry", "externals",
+    "loader", "module", "name", "node", "output", "plugins", "profile", "recordsInputPath",
+    "recordsOutputPath", "recordsPath", "resolve", "resolveLoader", "stats", "target", "watch",
+    "watchOptions"
+];
+
+module.exports = validWebpackOptions;

--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var mergeWith = require("lodash/mergeWith");
+var pick = require("lodash/pick");
 
 module.exports = function(grunt) {
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
@@ -69,7 +70,7 @@ module.exports = function(grunt) {
 			});
 		}
 
-		var compiler = webpack(_.pick(options.webpack, validWebpackOptions));
+		var compiler = webpack(pick(options.webpack, validWebpackOptions));
 
 		if(options.progress) {
 			var chars = 0;

--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -9,6 +9,8 @@ module.exports = function(grunt) {
 	var WebpackDevServer = require("webpack-dev-server");
 	var ProgressPlugin = require("webpack/lib/ProgressPlugin");
 
+	var validWebpackOptions = require("../lib/validWebpackOptions");
+
 	grunt.registerMultiTask('webpack-dev-server', 'Start a webpack-dev-server.', function() {
 		var done = this.async();
 		var options = mergeWith(
@@ -67,7 +69,7 @@ module.exports = function(grunt) {
 			});
 		}
 
-		var compiler = webpack(options.webpack);
+		var compiler = webpack(_.pick(options.webpack, validWebpackOptions));
 
 		if(options.progress) {
 			var chars = 0;

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -4,6 +4,7 @@ var mergeWith = require("lodash/mergeWith");
 var map = require("lodash/map");
 var isString = require("lodash/isString");
 var isArray = require("lodash/isArray");
+var pick = require("lodash/pick");
 
 module.exports = function(grunt) {
 	var getWithPlugins = require("../lib/getWithPlugins")(grunt);
@@ -85,7 +86,7 @@ module.exports = function(grunt) {
 		var statsOptions = firstOptions.stats;
 		var failOnError = firstOptions.failOnError;
 		var progress = firstOptions.progress;
-		var compiler = webpack(_.pick(options, validWebpackOptions));
+		var compiler = webpack(pick(options, validWebpackOptions));
 
 		if (cache) {
 			var theCachePlugin = targetCachePlugins[target];

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -13,6 +13,8 @@ module.exports = function(grunt) {
 	var CachePlugin = require("webpack/lib/CachePlugin");
 	var ProgressPlugin = require("webpack/lib/ProgressPlugin");
 
+	var validWebpackOptions = require("../lib/validWebpackOptions");
+
 	var targetCachePlugins = {};
 	var targetDependencies = {};
 
@@ -83,7 +85,7 @@ module.exports = function(grunt) {
 		var statsOptions = firstOptions.stats;
 		var failOnError = firstOptions.failOnError;
 		var progress = firstOptions.progress;
-		var compiler = webpack(options);
+		var compiler = webpack(_.pick(options, validWebpackOptions));
 
 		if (cache) {
 			var theCachePlugin = targetCachePlugins[target];


### PR DESCRIPTION
Hopefully fixes #81.

There are perhaps some issues with a whitelist approach, but overall it seems neater than a blacklist and a much simpler change than splitting the webpack config out entirely.