### PR TITLE
Fix for #90 - Error: Cannot find module

### DIFF
--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -17,7 +17,7 @@ class OptionHelper {
     const baseOptions = this.getWithPlugins([this.task.name, 'options']);
     if (Array.isArray(baseOptions)) throw new Error('webpack.options must be an object, but array was provided');
 
-    let options = defaults.mergeOptions(
+    const options = defaults.mergeOptions(
       this.getDefaultOptions(),
       baseOptions,
       this.getWithPlugins([this.task.name, this.task.target])

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -1,6 +1,6 @@
 'use strict';
 const defaults = require('./default');
-// const convertPaths = require('./convertPaths');
+const convertPaths = require('./convertPaths');
 
 class OptionHelper {
 
@@ -17,18 +17,21 @@ class OptionHelper {
     const baseOptions = this.getWithPlugins([this.task.name, 'options']);
     if (Array.isArray(baseOptions)) throw new Error('webpack.options must be an object, but array was provided');
 
-    return defaults.mergeOptions(
+    let options = defaults.mergeOptions(
       this.getDefaultOptions(),
       baseOptions,
       this.getWithPlugins([this.task.name, this.task.target])
     );
-
-    // disabled for now, it seems this is not necessary as webpack requires absolute paths for most stuff now
-    // if (Array.isArray(options)) {
-    //   options.forEach(convertPaths);
-    // } else {
-    //   convertPaths(options);
-    // }
+    
+    // https://webpack.github.io/docs/configuration.html#module-loaders
+    // The loaders here are resolved relative to the resource which they are applied to. 
+    // This means they are not resolved relative the the configuration file.
+    if (Array.isArray(options)) {
+      options.forEach(convertPaths);
+    } else {
+      convertPaths(options);
+    }
+    return options;
   }
 
   getOptions() {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  |no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | #90 
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

webpack actually uses relative paths so it is important to convert paths at least for loaders.

https://webpack.github.io/docs/configuration.html#module-loaders
```
IMPORTANT: The loaders here are resolved relative to the resource which they are applied to. This means they are not resolved relative the the configuration file. If you have loaders installed from npm and your node_modules folder is not in a parent folder of all source files, webpack cannot find the loader. You need to add the node_modules folder as absolute path to the resolveLoader.root option. (resolveLoader: { root: path.join(__dirname, "node_modules") })
```