### PR TITLE
Correct behavior of loading loaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
+    "awesome-typescript-loader": "^2.2.4",
     "babel-core": "^6.17.0",
     "babel-preset-latest": "^6.16.0",
     "eslint": "^3.6.1",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.5",
     "grunt": "^1.0.0",
+    "typescript": "^2.0.8",
     "webpack": "^2.1.0-beta"
   },
   "dependencies": {

--- a/src/options/default.js
+++ b/src/options/default.js
@@ -12,10 +12,6 @@ const gruntOptions = {
 };
 
 const webpackOptions = {
-  context: '.',
-  output: {
-    path: '.',
-  },
   stats: {},
 };
 

--- a/tests/fixtures/webpack/loader-path/Gruntfile.js
+++ b/tests/fixtures/webpack/loader-path/Gruntfile.js
@@ -1,0 +1,12 @@
+const loadGruntWebpackTasks = require('../../../utils/loadGruntWebpackTasks');
+
+module.exports = function (grunt) {
+    grunt.initConfig({
+        webpack: {
+            options: require('./webpack.config.js'),
+            dev: {}
+        }
+    });
+
+    loadGruntWebpackTasks(grunt);
+};

--- a/tests/fixtures/webpack/loader-path/exec.js
+++ b/tests/fixtures/webpack/loader-path/exec.js
@@ -1,2 +1,1 @@
 assertGrunt.success();
-

--- a/tests/fixtures/webpack/loader-path/main.ts
+++ b/tests/fixtures/webpack/loader-path/main.ts
@@ -1,0 +1,5 @@
+let test = (a: string) => {
+    console.log(a);
+}
+
+test('hello world');

--- a/tests/fixtures/webpack/loader-path/webpack.config.js
+++ b/tests/fixtures/webpack/loader-path/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+const config = {
+    entry: {
+        'main': './main.ts',
+    },
+    resolve: {
+        extensions: ['.ts', '.js'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                use: ['awesome-typescript-loader'],
+            },
+        ]
+    },
+};
+
+module.exports = config;
+

--- a/tests/utils/assertGrunt.js
+++ b/tests/utils/assertGrunt.js
@@ -1,14 +1,14 @@
 module.exports = function (t, returnCode, stdout) {
   return {
     success: function assertGruntSuccess() {
-      t.is(returnCode, 0, `Grunt exited with an error code stdout: "${stdout}"`);
+      t.is(returnCode, 0, `Grunt exited with an error code. stdout: "${stdout}"`);
 
-      // t.notRegex(stdout, /Aborted due to warnings./);
+      t.notRegex(stdout, /ERROR/i, `Webpack seems to run into an error. stdout: "${stdout}"`);
     },
     failed: function assertGruntSuccess() {
       t.true(returnCode > 0, `Grunt did not error as expected: "${stdout}"`);
 
-      // t.regex(stdout, /Aborted due to warnings./);
+      t.regex(stdout, /ERROR/i);
     }
   };
 };


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added?      | yes
| Docs updated?     | no
| Fixed tickets     | #90, #91
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes #90 #91

This removes the default values for context and output.path as this
breaks the default behaviour of webpack to use the cwd for these options.