### PR TITLE
Removed context default value

### DIFF
--- a/src/options/default.js
+++ b/src/options/default.js
@@ -32,7 +32,6 @@ const webpackDevServerOptions = {
   hot: false,
   contentBase: '.',
   webpack: {
-    context: '.',
     output: {
       path: '/'
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | [114](https://github.com/webpack/grunt-webpack/issues/114)
| License           | MIT

Removed the default value of *webpack-dev-server.webpack.context*, because it was an invalid value. See [the issue](https://github.com/webpack/grunt-webpack/issues/114) for more details.
